### PR TITLE
Break validation cycles in validateEntity

### DIFF
--- a/lib/masp-validator.js
+++ b/lib/masp-validator.js
@@ -1725,6 +1725,12 @@ class MaspValidator {
       return false;
     }
 
+    // Provisionally record this entity as valid for this rule before checking
+    // properties. Crates routinely contain cycles (pcdm:hasMember/pcdm:memberOf,
+    // image/isPartOf) and without this the property checks below would recurse
+    // back into this entity forever. The real result is stored at the end.
+    this.validatedEntities[entityId][classRule.id] = true;
+
     // Check for properties that reference this class via rangeIncludes
     const propertyRules = classRule.findPropertyRulesForClass();
     this.log(

--- a/test/cyclic-references.test.js
+++ b/test/cyclic-references.test.js
@@ -1,0 +1,122 @@
+const { expect } = require("chai");
+const { ROCrate } = require("ro-crate");
+const { MaspValidator } = require("../lib/masp-validator");
+
+// A minimal profile with a deliberate cycle: the Collection's pcdm:hasMember
+// ranges on the Object class and the Object's pcdm:memberOf ranges back on the
+// Collection class. Validating either entity has to walk into the other.
+const PROFILE = {
+  "@context": ["https://w3id.org/ro/crate/1.2/context", { "@vocab": "http://schema.org/" }],
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "conformsTo": { "@id": "https://w3id.org/ro/crate/1.2" },
+      "about": { "@id": "./" },
+    },
+    {
+      "@id": "./",
+      "@type": ["Dataset", "Profile"],
+      "name": "Cycle test profile",
+      "hasResource": [{ "@id": "#hasSchema" }],
+    },
+    {
+      "@id": "#hasSchema",
+      "@type": "ResourceDescriptor",
+      "name": "Schema",
+      "hasRole": { "@id": "http://www.w3.org/ns/dx/prof/role/schema" },
+      "hasPart": [
+        { "@id": "#Class_Collection" },
+        { "@id": "#Class_Object" },
+        { "@id": "#prop_hasMember" },
+        { "@id": "#prop_memberOf" },
+      ],
+    },
+    {
+      "@id": "#Class_Collection",
+      "@type": "rdfs:Class",
+      "name": "Collection",
+      "prov:specializationOf": [
+        { "@id": "http://schema.org/Dataset" },
+        { "@id": "http://pcdm.org/models#Collection" },
+      ],
+      "sh:minCount": 1,
+      "sh:maxCount": 1,
+    },
+    {
+      "@id": "#Class_Object",
+      "@type": "rdfs:Class",
+      "name": "Object",
+      "prov:specializationOf": { "@id": "http://pcdm.org/models#Object" },
+      "sh:minCount": 1,
+    },
+    {
+      "@id": "#prop_hasMember",
+      "@type": "rdf:Property",
+      "name": "pcdm:hasMember",
+      "rdfs:label": "pcdm:hasMember",
+      "domainIncludes": { "@id": "#Class_Collection" },
+      "rangeIncludes": { "@id": "#Class_Object" },
+      "sh:minCount": 1,
+    },
+    {
+      "@id": "#prop_memberOf",
+      "@type": "rdf:Property",
+      "name": "pcdm:memberOf",
+      "rdfs:label": "pcdm:memberOf",
+      "domainIncludes": { "@id": "#Class_Object" },
+      "rangeIncludes": { "@id": "#Class_Collection" },
+      "sh:minCount": 1,
+      "sh:maxCount": 1,
+    },
+  ],
+};
+
+function targetCrate() {
+  return {
+    "@context": ["https://w3id.org/ro/crate/1.2/context", { "@vocab": "http://schema.org/" }],
+    "@graph": [
+      {
+        "@id": "ro-crate-metadata.json",
+        "@type": "CreativeWork",
+        "conformsTo": { "@id": "https://w3id.org/ro/crate/1.2" },
+        "about": { "@id": "./" },
+      },
+      {
+        "@id": "./",
+        "@type": ["Dataset", "RepositoryCollection"],
+        "name": "A collection",
+        "pcdm:hasMember": { "@id": "#object1" },
+      },
+      {
+        "@id": "#object1",
+        "@type": "RepositoryObject",
+        "name": "An object",
+        "pcdm:memberOf": { "@id": "./" },
+      },
+    ],
+  };
+}
+
+async function validate(target) {
+  const validator = new MaspValidator(new ROCrate(PROFILE, { array: true, link: true }));
+  return validator.validateCrate(new ROCrate(target, { array: true, link: true }));
+}
+
+describe("MaspValidator – cyclic entity references", function () {
+  this.timeout(10000);
+
+  it("validates a hasMember/memberOf cycle instead of recursing forever", async function () {
+    const results = await validate(targetCrate());
+    expect(results.error).to.eql([]);
+    expect(results.success.length).to.equal(2);
+  });
+
+  it("still reports a broken entity inside a cycle", async function () {
+    const target = targetCrate();
+    // Drop the back-link the Object rule requires.
+    delete target["@graph"].find((e) => e["@id"] === "#object1")["pcdm:memberOf"];
+    const results = await validate(target);
+    expect(results.error.some((e) => /Object/.test(e.message))).to.be.true;
+  });
+});


### PR DESCRIPTION
Fixes #32.

`validateEntity()` recorded its result in `validatedEntities` only after running the entity's property rules, so two entities referencing each other through `rangeIncludes` recursed until the stack overflowed:

```
Validation failed: Maximum call stack size exceeded
```

The cycles that trigger it are ordinary modelling — `pcdm:hasMember`/`pcdm:memberOf` between a collection and its members, `image`/`isPartOf` between an object and its files. Until now the workaround was to drop `rangeIncludes` from one side, which loses a real constraint.

## The change

One line plus a comment in `validateEntity()`: record the entity provisionally after its types check out, before descending into its property rules, and let the existing assignment at the end overwrite it with the real result. This is the standard cycle break for a recursive graph walk — the entity being validated is assumed to hold while its own subtree is checked.

## Testing

- New `test/cyclic-references.test.js` — a self-contained profile/crate pair with a `hasMember`/`memberOf` cycle. Two cases: the cycle validates, and a broken entity *inside* a cycle is still reported. Both fail on `main` (the first with a stack overflow).
- Full suite: 196 passing, no existing test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)